### PR TITLE
Fix of upper BC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ CODT
 build/
 fpm_env
 fpm.toml
+.vscode/

--- a/src/globals.f90
+++ b/src/globals.f90
@@ -39,6 +39,7 @@ module globals
     real(dp), parameter :: nu = 1.488e-5           ! Kinematic Viscosity
     real(dp), parameter :: kT = 1.96e-5           ! Heat Diffusivity (Dt is timestep...)
     real(dp), parameter :: Dv = 2.2705e-5          ! Mass Diffusivity of water vapor
+    real(dp), parameter :: Ndnu = 1.                ! For nondim diffusion of velocity
     real(dp), parameter :: Pr = nu/kT               ! Prandtl Number
     real(dp), parameter :: Sc = nu/Dv              ! Schmidt Number
 

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -11,7 +11,7 @@ module initialize
 
     integer(i4) :: write_buffer ! Buffer size, n iterations to write to netCDF
     
-    private :: allocate_zero_arrays, initialize_velocity_arrays, initialize_scalar_arrays, initialize_params
+    private :: allocate_zero_arrays, initialize_velocity_arrays, initialize_params
     public :: initialize_simulation
     
 contains
@@ -137,10 +137,10 @@ contains
         ! Allocate scalar/vector fields
         write(*,*) 'Allocating arrays...'
         call allocate_zero_arrays(z, N)
-        call allocate_zero_arrays(W, N)
-        call allocate_zero_arrays(T, N)
-        call allocate_zero_arrays(WV, N)
-        call allocate_zero_arrays(Tv, N)
+        call allocate_nondim_array(W, N)
+        call allocate_nondim_array(T, N)
+        call allocate_nondim_array(WV, N)
+        call allocate_nondim_array(Tv, N)
         call allocate_zero_arrays(Tdim, N)
         call allocate_zero_arrays(WVdim, N)
         call allocate_zero_arrays(Tvdim, N)
@@ -152,7 +152,6 @@ contains
         ! NOTE THIS ONLY HAS POSITIVE PERTURBATIONS - NONDIMENSIONAL???
         !W = W + random_array(W)*2.e-10
 
-        call initialize_scalar_arrays(T, WV)
         call initialize_velocity_arrays(W)
         call update_dim_scalars(W, T, WV, Tv, Wdim, Tdim, WVdim, Tvdim)
         call update_supersat(Tdim, WVdim, SS, pres)
@@ -188,12 +187,29 @@ contains
 
     end subroutine initialize_params
 
+    subroutine allocate_nondim_array(A, n_array)
+        integer(i4), intent(in) ::n_array
+        real(dp), intent(inout), allocatable :: A(:)
+        integer :: k
 
+        ! Set nondimensional arrays to have a ghost point at top/bottom
+        n_ghost = n_array+1
+        allocate(A(0:n_ghost))
+        A = 0.
+
+        ! Bottom Ghost - 0
+        ! Top Ghost - 1
+        do concurrent (k = 0, n_ghost)
+            A(k) = 1.*k/(n_ghost)
+        end do
+
+    end subroutine allocate_nondim_array
 
     subroutine allocate_zero_arrays(A, n_array)
         integer(i4), intent(in) ::n_array
         real(dp), intent(inout), allocatable :: A(:)
 
+        ! Dimensional arrays do not have ghost points
         allocate(A(n_array))
         A = 0.
 
@@ -206,26 +222,13 @@ contains
         real(dp) :: rand_num
         integer(i4) :: k
 
-        do k = 1, N-1
+        lw(0) = 0.
+        do k = 1, N
             call random_number(rand_num)
             lw(k) = 2.e-10 * (rand_num - 0.5)
         end do
+        lw(N+1) = 0.
 
     end subroutine initialize_velocity_arrays
-
-
-    subroutine initialize_scalar_arrays(lT, lWV)
-        real(dp), intent(out) :: lT(:), lWV(:)
-        integer(i4) :: k
-        real(dp) :: lin_prof
-
-        ! Non-Dimensional Values
-        do concurrent (k = 1:N)
-            lin_prof = 1.*k/N
-            lT(k) = lin_prof
-            lWV(k) = lin_prof
-        end do
-
-    end subroutine initialize_scalar_arrays
 
 end module initialize

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -152,6 +152,7 @@ contains
         ! NOTE THIS ONLY HAS POSITIVE PERTURBATIONS - NONDIMENSIONAL???
         !W = W + random_array(W)*2.e-10
 
+        call initialize_linear_array(z)
         call initialize_velocity_arrays(W)
         call update_dim_scalars(W, T, WV, Tv, Wdim, Tdim, WVdim, Tvdim)
         call update_supersat(Tdim, WVdim, SS, pres)
@@ -193,14 +194,12 @@ contains
         integer :: k
 
         ! Set nondimensional arrays to have a ghost point at top/bottom
-        n_ghost = n_array+1
-        allocate(A(0:n_ghost))
+        allocate(A(N+1))
         A = 0.
 
-        ! Bottom Ghost - 0
-        ! Top Ghost - 1
-        do concurrent (k = 0, n_ghost)
-            A(k) = 1.*k/(n_ghost)
+        ! Initialize nondim with lenear profile
+        do concurrent (k = 1:N+1)
+            A(k) = 1.*k/(N+1)
         end do
 
     end subroutine allocate_nondim_array
@@ -215,6 +214,17 @@ contains
 
     end subroutine allocate_zero_arrays
 
+    subroutine initialize_linear_array(array)
+
+        real(dp), intent(out) :: array(:)
+        integer :: k
+
+        do concurrent (k = 1:N)
+            array(k) = 1.*k/N
+        end do
+
+    end subroutine initialize_linear_array
+
     subroutine initialize_velocity_arrays(lw)
         ! Initializes velcoity arrays with some noise. This prevents a numerical issue from
         ! occuring when calculating the kinetic energy (i.e. KE != 0)
@@ -222,7 +232,6 @@ contains
         real(dp) :: rand_num
         integer(i4) :: k
 
-        lw(0) = 0.
         do k = 1, N
             call random_number(rand_num)
             lw(k) = 2.e-10 * (rand_num - 0.5)


### PR DESCRIPTION
Additional gridpoint at the upper boundary in non dimensional scalar arrays prevents the "boundary condition" from being overwritten by the DGM. Array initialization and diffusion subroutine account for this additional grid point. CLOSES: #2 