### PR TITLE
Creating Sub-categorical DSDs for specific aerosols

### DIFF
--- a/input/injection_data.txt
+++ b/input/injection_data.txt
@@ -15,6 +15,8 @@ Must be N injection Times long
 N Bin Edges (nanometers):
 3
 60 70 4930
+Aerosol Category:
+1 2
 Relative Frequencies (%):
 Must be N bin Edges - 1 columns
 with N injection Times rows

--- a/src/droplets.f90
+++ b/src/droplets.f90
@@ -77,6 +77,7 @@ module droplets
     real(dp), allocatable :: injection_times(:), injection_rates(:) ! allocated in read_injection_data()
     real(dp), allocatable :: aerosol_size_edges(:), aerosol_bin_freq(:,:) ! allocated in read_injection_data()
     real(dp), allocatable :: aerosol_radii(:) ! allocated in read_injection_data()
+    integer(i4), allocatable :: aerosol_partition(:)
     real(dp) :: last_injection_time
     real(dp) :: injection_dt
     integer(i4) :: n_injected, inj_time_idx
@@ -773,15 +774,13 @@ contains
     subroutine initialize_microphysics(filename)
         ! Initialization of the MICROPHYSICS namelist and related parameters
         character(*), intent(in) :: filename
-        integer     :: ierr, nml_unit
+        integer     :: ierr, nml_unit, i
         character(100) :: nml_line, io_emsg
         
         ! Microphysics namelist variables for initialization only
         logical :: init_drop_each_gridpoint = .true.
         real(dp) :: expected_Ndrops_per_gridpoint = 1
         character(100):: inj_data_path, bin_data_path ! Not allocatable since namelist-specified variable
-
-        integer(i4) :: i
 
         namelist /MICROPHYSICS/ init_drop_each_gridpoint, expected_Ndrops_per_gridpoint, inj_data_path, &
         bin_data_path, write_trajectories, trajectory_start, trajectory_end, trajectory_timer, initial_wet_radius
@@ -935,7 +934,7 @@ contains
 
         character(10) :: name
         integer :: n_ions
-        integer :: n_times, n_edges
+        integer :: n_times, n_edges, n_aer_partition
         real(dp) :: molar_mass, density
 
         ! Open the injection data file
@@ -972,6 +971,9 @@ contains
         allocate(aerosol_size_edges(n_edges))
         read(file_unit, *, iostat=ierr) aerosol_size_edges
         if ( ierr /= 0) then; write(*,*) 'Error reading size edges'; stop; end if
+        read(file_unit, *) ! Aerosol Category
+        allocate(aerosol_partition(n_edges - 1))
+        read(file_unit, *) aerosol_partition
         read(file_unit, *) ! Bin Frequencies:
         read(file_unit, *)
         read(file_unit, *)

--- a/src/droplets.f90
+++ b/src/droplets.f90
@@ -44,6 +44,7 @@ module droplets
         type(aerosol) :: solute_type = aerosol()    ! Type of aerosol particle
         real(dp) :: solute_gross_mass = 0.0      ! Gross mass of the solute in the particle (kg)
         real(dp) :: solute_radius = 0.0        ! Radius of the dry-solute in the particle (m)
+        integer(i4) :: aerosol_category = 1
 
         logical :: activated = .false.
         logical :: fellout = .false.
@@ -516,7 +517,8 @@ contains
         this%fellout = .false.
 
         ! Determine solute properties (sampled from injection_data.txt) and initial radius
-        this%solute_radius = sample_radius(aerosol_bin_freq(inj_time_idx,:), aerosol_radii)
+        !this%solute_radius = sample_radius(aerosol_bin_freq(inj_time_idx,:), aerosol_radii)
+        call sample_radius(aerosol_bin_freq(inj_time_idx,:), aerosol_radii, this%solute_radius, this%aerosol_category)
         this%solute_gross_mass = ( pi_43 * this%solute_type%solute_density ) * this%solute_radius**3
         this%radius = initial_wet_radius * this%solute_radius
 
@@ -528,10 +530,12 @@ contains
 
     end subroutine particle_initialize
 
-    function sample_radius(bin_freq, radii) result(radius)
+    subroutine sample_radius(bin_freq, radii, radius, aer_partition)
         ! Selects an aerosol size from distribution specified in injection_data.txt
         real(dp), intent(in) :: bin_freq(:), radii(:)
-        real(dp) :: random_num, radius
+        real(dp), intent(out) :: radius
+        integer(i4), intent(out) :: aer_partition
+        real(dp) :: random_num
         integer :: idx
 
         ! Generate a random number between 0 and 1
@@ -542,11 +546,10 @@ contains
             idx = idx + 1
         end do
 
-        !write(*,*) random_num, idx, bin_freq(idx), radii(idx)
-
         radius = radii(idx) * m_per_nm
+        aer_partition = aerosol_partition(idx)
 
-    end function sample_radius
+    end subroutine sample_radius
 
     !-----------------------------------------------------------
 

--- a/src/droplets.f90
+++ b/src/droplets.f90
@@ -927,7 +927,7 @@ contains
     subroutine read_binning_data(location, n_cat, bin_edges, DSD)
         ! Acquires the bin edges for particle/droplet size distribution calculations
         character(*), intent(in) :: location
-        integer, intent(in) :: n_cat
+        integer, intent(in), value :: n_cat
         real(dp), allocatable, intent(out) :: bin_edges(:)
         integer, allocatable, intent(out) :: DSD(:,:)
         integer :: i, ierr, file_unit

--- a/src/droplets.f90
+++ b/src/droplets.f90
@@ -1136,22 +1136,22 @@ contains
 
         ! Then cycle through each aerosol category and create a DSD for that
         if ( n_aer_category > 1 ) then
-            do j = 2, n_aer_category
+            do j = 1, n_aer_category
                 n_particles = 0
                 include_cat = .false.
 
                 ! Determine which droplets belong to which category
-                do i = 1, current_n_particles
+                do concurrent (i = 1:current_n_particles)
                     if ( droplets(i)%aerosol_category == j ) then
                         include_cat(i) = .true.
-                        n_particles = n_particles + 1
                     end if
                 end do
+                n_particles = count(include_cat)
 
                 ! Create array of those droplet radii and bin them
                 allocate(cat_radii(n_particles))
                 cat_radii(:) = pack(radii, include_cat)
-                histogram(j,:) = bin_data(bin_edges, cat_radii)
+                histogram(j+1,:) = bin_data(bin_edges, cat_radii)
                 deallocate(cat_radii)
 
             end do

--- a/src/droplets.f90
+++ b/src/droplets.f90
@@ -517,7 +517,6 @@ contains
         this%fellout = .false.
 
         ! Determine solute properties (sampled from injection_data.txt) and initial radius
-        !this%solute_radius = sample_radius(aerosol_bin_freq(inj_time_idx,:), aerosol_radii)
         call sample_radius(aerosol_bin_freq(inj_time_idx,:), aerosol_radii, this%solute_radius, this%aerosol_category)
         this%solute_gross_mass = ( pi_43 * this%solute_type%solute_density ) * this%solute_radius**3
         this%radius = initial_wet_radius * this%solute_radius

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -4,8 +4,9 @@ module initialize
     use ODT, only: calc_eddy_length_cdf, diffusion
     use special_effects, only: initialize_special_effects
     use writeout, only: initialize_buffers, create_netcdf, initialize_particle_buffers, &
-    initialize_eddy_buffer, add_to_profile_buffer, flush_buffer, close_netcdf
-    use droplets, only: initialize_microphysics, n_DSD_bins, size_distribution, write_trajectories, close_droplets
+                initialize_eddy_buffer, add_to_profile_buffer, flush_buffer, close_netcdf
+    use droplets, only: initialize_microphysics, n_DSD_bins, n_aer_category, size_distribution, &
+                write_trajectories, close_droplets
     use write_particle, only: initialize_write_particle, close_particle_files
     implicit none
 
@@ -30,7 +31,7 @@ contains
         
         if ( do_microphysics ) then
             call initialize_microphysics(filename)
-            call initialize_particle_buffers(n_DSD_bins)
+            call initialize_particle_buffers(n_aer_category, n_DSD_bins)
             ! Wont work right now if init_drop_each_gridpoint = .false.
             if ( write_trajectories ) call initialize_write_particle(output_directory)
         end if

--- a/src/writeout.f90
+++ b/src/writeout.f90
@@ -65,7 +65,12 @@ contains
 
         integer(i4), intent(in) :: n_cat, n_bins
 
-        allocate(buffer_DSD(n_cat, n_bins, buffer_size))
+        if ( n_cat > 1 ) then
+            ! Account for subcategorical DSDs
+            allocate(buffer_DSD(n_cat+1, n_bins, buffer_size))
+        else
+            allocate(buffer_DSD(1, n_bins, buffer_size))
+        end if
         buffer_DSD = 0
 
     end subroutine initialize_particle_buffers
@@ -350,11 +355,11 @@ contains
 
             ! Write the subcategory DSDs
             if ( n_aer_category > 1 ) then
-                do i = 2, n_aer_category
+                do i = 1, n_aer_category
                     write(strint,*) i
                     varname = "DSD_" // adjustl(strint)
                     call nc_verify( nf90_inq_varid(lncid, trim(varname), DSDid ))
-                    call nc_verify( nf90_put_var(ncid, DSDid, lDSD(i,:,:), start=start_dim, count=count_dim) )
+                    call nc_verify( nf90_put_var(ncid, DSDid, lDSD(i+1,:,:), start=start_dim, count=count_dim) )
                 end do
             end if
 

--- a/src/writeout.f90
+++ b/src/writeout.f90
@@ -70,7 +70,14 @@ contains
             allocate(buffer_DSD(n_cat+1, n_bins, buffer_size))
         else
             allocate(buffer_DSD(1, n_bins, buffer_size))
+        ! Calculate number of DSDs (n_cat + 1 for multiple categories, 1 otherwise)
+        integer(i4) :: n_DSDs
+        if ( n_cat > 1 ) then
+            n_DSDs = n_cat + 1
+        else
+            n_DSDs = 1
         end if
+        allocate(buffer_DSD(n_DSDs, n_bins, buffer_size))
         buffer_DSD = 0
 
     end subroutine initialize_particle_buffers


### PR DESCRIPTION
Each aerosol size bin can be assigned to an "aerosol category". A DSD will be written to the netCDF for droplets corresponding with each individual aerosol category, alongside the DSD for all droplets.